### PR TITLE
chore: exclude claude.yml from yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,6 +5,7 @@ ignore: |
   .venv/
   venv/
   node_modules/
+  .github/workflows/claude.yml
 
 rules:
   line-length:


### PR DESCRIPTION
Fixes #8

Excluded `.github/workflows/claude.yml` from yamllint to prevent formatter errors in GitHub Actions.

Generated with [Claude Code](https://claude.ai/code)